### PR TITLE
feat: add /save-session command to index sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Custom slash commands for common workflows.
 | `/fix-issue <number>` | Fetch a GitHub issue and implement the fix |
 | `/audit` | Run full production audit with both agents |
 | `/start-feature` | Start the feature development pipeline from `workflow.md` |
+| `/save-session` | Save a high-density summary of the current session to `.claude_sessions.md` |
 
 ### 🔌 Claude Plugins
 

--- a/editors/claude/commands/save-session.md
+++ b/editors/claude/commands/save-session.md
@@ -1,0 +1,40 @@
+---
+description: Save a high-density summary of the current session to .claude_sessions.md
+---
+
+Save this session to the project's session index so it can be resumed later with `claude --resume`.
+
+Optional name: $ARGUMENTS
+
+Today's date: !`date +%Y-%m-%d`
+Project root: !`git rev-parse --show-toplevel 2>/dev/null || pwd`
+Resume command: !`SID="${CLAUDE_SESSION_ID:-$(cd "$HOME/.claude/projects/$(pwd|sed 's#[/.]#-#g')" 2>/dev/null && /bin/ls -t *.jsonl 2>/dev/null | head -1 | sed 's/\.jsonl$//')}"; [ -n "$SID" ] && echo "claude --resume $SID" || echo "(session id not found)"`
+
+Steps:
+
+1. **Name** the session in kebab-case (e.g. `stripe-webhook-fix-v1`). Use the name in `$ARGUMENTS` if given; otherwise derive a short, descriptive one from what we worked on. If a name already exists in the file, suffix `-v2`, `-v3`, etc.
+2. **Summarize** in exactly 3 dense sentences: the problem, the context/decisions established, and the current state or next step. No filler. Optimize for a future agent re-loading this context cold.
+3. **Append** the entry below to `.claude_sessions.md` in the project root, newest first (right under the `## Sessions` header). Create the file from the template if it does not exist. Use the resume command captured above verbatim.
+
+Entry format:
+
+```
+### <session-name>
+- **Date:** <today>
+- **Resume:** `claude --resume <id>`
+
+<3-sentence summary>
+```
+
+File template (only when creating):
+
+```
+# Claude Sessions
+
+Index of sessions worth resuming. Git-ignored (global).
+Resume any entry with its `claude --resume <id>` command from this project root.
+
+## Sessions
+```
+
+After writing, print the session name, the resume command, and the 3-sentence summary.

--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -37,6 +37,7 @@ tmp/
 
 # Custom
 .no-commit
+.claude_sessions.md
 
 # superpowers
 superpowers/


### PR DESCRIPTION
## Description

Adds a `/save-session` slash command to capture a Claude Code session worth resuming later, plus the plumbing to keep its index file out of git.

When run at the end of a good session, the command:
1. Names the session in kebab-case (uses `$ARGUMENTS` if given, else derives one).
2. Writes a 3-sentence high-density context summary, optimized for a future agent re-loading cold.
3. Captures the session's `claude --resume <id>` command automatically (from `$CLAUDE_SESSION_ID`, falling back to the newest log in `~/.claude/projects/<cwd>/`), so nothing has to be supplied by hand.
4. Prepends the entry (name, date, resume command) to `.claude_sessions.md` in the project root, newest first, creating the file from a template if missing.

Resume later from the project root: copy the entry's `claude --resume <id>` command.

## Type of Change

- New feature (Claude command)
- Workflow / tooling

## Changes

| File | Change |
|---|---|
| `editors/claude/commands/save-session.md` | New `/save-session` command |
| `git/.gitignore_global` | Ignore `.claude_sessions.md` in every repo |
| `README.md` | Document the command in the commands table |

## Notes

- `.claude_sessions.md` is intentionally **not** committed: it is a local, git-ignored index.
- The global ignore takes effect once `core.excludesfile` points at `~/.gitignore_global` (README install steps).
- Session id is read from `$CLAUDE_SESSION_ID` when set, else the most-recently-modified `*.jsonl` in the project's session dir (the active session). `/bin/ls` is used to bypass any `ls` alias.

## Testing

- Verified id detection on this machine resolves to the active session's resume command.
- `~/.claude/commands` symlinks to the dotfiles dir, so `/save-session` is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
