### PR TITLE
feat: auto-symlink .venv when Claude starts in a Python git worktree

### DIFF
--- a/editors/claude/hooks/python-worktree-venv.sh
+++ b/editors/claude/hooks/python-worktree-venv.sh
@@ -2,6 +2,15 @@
 # Symlink .venv from main repo when Claude starts inside a Python git worktree.
 set -euo pipefail
 
+# SessionStart passes a JSON payload on stdin whose `cwd` is the session's real
+# working directory. With `--worktree` the hook process inherits the launch
+# directory (the main checkout), not the worktree, so trust the payload instead.
+if [[ ! -t 0 ]]; then
+  PAYLOAD=$(cat)
+  CWD=$(printf '%s' "$PAYLOAD" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("cwd",""))' 2>/dev/null || true)
+  [[ -n "$CWD" && -d "$CWD" ]] && cd "$CWD"
+fi
+
 # Must be inside a git repo
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0

--- a/editors/claude/hooks/python-worktree-venv.sh
+++ b/editors/claude/hooks/python-worktree-venv.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Symlink .venv from main repo when Claude starts inside a Python git worktree.
+set -euo pipefail
+
+# Must be inside a git repo
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+GIT_DIR_ABS=$(cd "$GIT_DIR" && pwd -P)
+GIT_COMMON_ABS=$(cd "$GIT_COMMON" && pwd -P)
+
+# Not a worktree — nothing to do
+[[ "$GIT_DIR_ABS" == "$GIT_COMMON_ABS" ]] && exit 0
+
+# Not a Python project
+[[ -f pyproject.toml ]] || [[ -f requirements.txt ]] || exit 0
+
+# .venv already present (real or symlink)
+[[ -e .venv ]] && exit 0
+
+MAIN_ROOT=$(cd "$GIT_COMMON_ABS/.." && pwd -P)
+
+if [[ ! -d "$MAIN_ROOT/.venv" ]]; then
+  echo "Python worktree detected but $MAIN_ROOT/.venv missing. Run 'uv sync' in the main repo first."
+  exit 0
+fi
+
+ln -s "$MAIN_ROOT/.venv" .venv
+echo "Python worktree: symlinked .venv from $MAIN_ROOT"

--- a/editors/claude/hooks/python-worktree-venv.sh
+++ b/editors/claude/hooks/python-worktree-venv.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Symlink .venv from main repo when Claude starts inside a Python git worktree.
+# Link shared, gitignored dev files (.venv, .env) from the main repo into a
+# Python git worktree so tests and management commands run without re-setup.
 set -euo pipefail
 
 # SessionStart passes a JSON payload on stdin whose `cwd` is the session's real
@@ -24,15 +25,21 @@ GIT_COMMON_ABS=$(cd "$GIT_COMMON" && pwd -P)
 # Not a Python project
 [[ -f pyproject.toml ]] || [[ -f requirements.txt ]] || exit 0
 
-# .venv already present (real or symlink)
-[[ -e .venv ]] && exit 0
-
 MAIN_ROOT=$(cd "$GIT_COMMON_ABS/.." && pwd -P)
 
-if [[ ! -d "$MAIN_ROOT/.venv" ]]; then
+# Symlink an item from the main repo if the worktree lacks it.
+link_shared() {
+  local name=$1
+  [[ -e "$name" || -L "$name" ]] && return 0       # worktree already has it
+  [[ -e "$MAIN_ROOT/$name" ]] || return 0           # main repo lacks it
+  ln -s "$MAIN_ROOT/$name" "$name"
+  echo "Worktree: linked $name from $MAIN_ROOT"
+}
+
+if [[ ! -e .venv && ! -L .venv && ! -d "$MAIN_ROOT/.venv" ]]; then
   echo "Python worktree detected but $MAIN_ROOT/.venv missing. Run 'uv sync' in the main repo first."
-  exit 0
 fi
 
-ln -s "$MAIN_ROOT/.venv" .venv
-echo "Python worktree: symlinked .venv from $MAIN_ROOT"
+link_shared .venv
+link_shared .env
+link_shared .env.local

--- a/editors/claude/settings.json
+++ b/editors/claude/settings.json
@@ -22,6 +22,18 @@
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.dotfiles/editors/claude/hooks/python-worktree-venv.sh"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Add `SessionStart` hook that detects when Claude opens inside a Python git worktree and symlinks `.venv` from the main repo root instead of reinstalling dependencies.
- Hook is a no-op outside worktrees, for non-Python projects, or when `.venv` already exists.
- Warns if the main repo's `.venv` is missing rather than silently failing.

## How it works

```
SessionStart
  └─ python-worktree-venv.sh
       ├─ git rev-parse --git-dir vs --git-common-dir  →  detect worktree
       ├─ pyproject.toml | requirements.txt present?   →  Python project check
       ├─ .venv absent?                                →  skip if already set up
       └─ ln -s $MAIN_ROOT/.venv .venv                 →  zero-cost shared venv
```

`MAIN_ROOT` is resolved via `cd $(git rev-parse --git-common-dir)/.. && pwd -P`, which is portable across any worktree layout.

## Test plan

- [ ] Open Claude in a normal repo: hook exits silently, no `.venv` created
- [ ] Open Claude in a Python worktree with main `.venv` present: `.venv` symlink appears automatically
- [ ] Open Claude in a Python worktree with no main `.venv`: warning printed, no crash
- [ ] Open Claude in a non-Python worktree: hook exits silently
